### PR TITLE
Parameters are in wrong order in CommandBuilder

### DIFF
--- a/lib/command_builder.dart
+++ b/lib/command_builder.dart
@@ -63,7 +63,7 @@ class CommandBuilder<TParam, TResult> extends StatelessWidget {
                   ? (lastData, paramData) =>
                       whileExecuting!.call(context, lastData, paramData)
                   : null,
-          onError: (lastData, error, paramData) {
+          onError: (error, lastData, paramData) {
             if (onError == null) {
               return const SizedBox();
             }

--- a/lib/command_builder.dart
+++ b/lib/command_builder.dart
@@ -23,8 +23,8 @@ class CommandBuilder<TParam, TResult> extends StatelessWidget {
   whileExecuting;
   final Widget Function(
     BuildContext context,
-    Object,
     TResult? lastValue,
+    Object,
     TParam?,
   )?
   onError;

--- a/lib/command_builder.dart
+++ b/lib/command_builder.dart
@@ -23,8 +23,8 @@ class CommandBuilder<TParam, TResult> extends StatelessWidget {
   whileExecuting;
   final Widget Function(
     BuildContext context,
-    TResult? lastValue,
     Object,
+    TResult? lastValue,
     TParam?,
   )?
   onError;
@@ -72,7 +72,7 @@ class CommandBuilder<TParam, TResult> extends StatelessWidget {
               'This CommandBuilder received an error from Command ${command.name} '
               'but the errorReaction indidates that the error should not be handled locally. ',
             );
-            return onError!.call(context, lastData, error, paramData);
+            return onError!.call(context, error, lastData, paramData);
           },
         );
       },


### PR DESCRIPTION
Not an error per se, but I was inspecting the code to name variables accordingly and it was confusing as name was wrong