### PR TITLE
fix: complete future with current value instead of null

### DIFF
--- a/lib/command_it.dart
+++ b/lib/command_it.dart
@@ -817,7 +817,7 @@ abstract class Command<TParam, TResult> extends CustomValueNotifier<TResult> {
       _errors.dispose();
       _handle?.dispose();
       if (!(_futureCompleter?.isCompleted ?? true)) {
-        _futureCompleter!.complete(null);
+        _futureCompleter!.complete(value);
         _futureCompleter = null;
       }
 

--- a/test/flutter_command_test.dart
+++ b/test/flutter_command_test.dart
@@ -2135,6 +2135,25 @@ void main() {
       final result = await future;
       expect(result, null);
     });
+
+    test('Dispose while future is pending completes it with current value',
+        () async {
+      final command = Command.createAsyncNoParam<String>(
+        () async {
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+          return 'result';
+        },
+        initialValue: 'initial',
+      );
+
+      final future = command.runAsync();
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      command.dispose();
+
+      final result = await future;
+      expect(result, 'initial');
+    });
   });
 
   group('Command Utilities and Properties', () {


### PR DESCRIPTION
A disposed command_it command completed its pending runAsync() future with null, crashing for non-nullable result types like Completer<bool>